### PR TITLE
Issue #266 - Draw border around non transparent part of PNG image

### DIFF
--- a/src/js/core/base-layers.js
+++ b/src/js/core/base-layers.js
@@ -49,7 +49,6 @@ class Base_layers_class {
             return instance;
         }
         instance = this;
-
         this.Base_gui = new Base_gui_class();
         this.Helper = new Helper_class();
         this.Image_trim = new Image_trim_class();
@@ -93,6 +92,10 @@ class Base_layers_class {
         );
 
         this.render(true);
+    }
+
+    getZoomView() {
+        return zoomView;
     }
 
     init_zoom_lib() {

--- a/src/js/libs/image-border-effect.js
+++ b/src/js/libs/image-border-effect.js
@@ -10,21 +10,114 @@ function hexToRgb(hex) {
         : [0, 0, 0];
 }
 
-const drawBorder = (ctx, hexColor) => {
-    const width = ctx.canvas.width,
-        height = ctx.canvas.height;
-    const imageData = ctx.getImageData(0, 0, width, height);
+/**
+ * Detects the shapes from the list of points then creates
+ * separate list of points for each shape. In every shapes
+ * the points are ordered so that it's possible to draw the shape
+ * just iterating one by one
+ * @param {number[][]} points
+ * @returns {number[][]}
+ */
+function constructShapes(points) {
+    const shapes = [];
 
-    const dataCopy = new Uint8ClampedArray(imageData.data);
+    points.map((point) => {
+        let shapeIndex = -1;
+        let closestPointIndex = -1;
+
+        shapes.map((shape, index) => {
+            let { index: _closestPointIndex, ...rest } = getClosestPoint(
+                shape,
+                point,
+                2
+            );
+            if (_closestPointIndex >= 0) {
+                shapeIndex = index;
+                closestPointIndex = _closestPointIndex;
+            }
+        });
+
+        if (shapeIndex === -1) {
+            shapes.push([]);
+            shapeIndex = shapes.length - 1;
+            closestPointIndex = 0;
+        }
+        let nextPoint = shapes[shapeIndex][closestPointIndex + 1];
+        if (
+            !nextPoint ||
+            nextPoint[0] != point[0] ||
+            nextPoint[1] != point[1]
+        ) {
+            shapes[shapeIndex].splice(closestPointIndex + 1, 0, point);
+        }
+    });
+    return shapes;
+}
+
+/**
+ *
+ * @param {number[][]} points
+ * @param {number[]} point
+ * @param {number} distance
+ * @returns
+ */
+function getClosestPoint(points, point, distance) {
+    let dist = distance + 1;
+    let i = -1;
+    points.map((nextPoint, index) => {
+        const d = getDistance(point, nextPoint);
+        if (d !== 0 && d < dist) {
+            i = index;
+            dist = d;
+        }
+    });
+
+    if (dist > distance || i === -1) return { closestPoint: null };
+
+    return { closestPoint: points[i], index: i };
+}
+
+/**
+ * Calculates the distance between to coordinates
+ * @param {number[]} point1
+ * @param {number[]} point2
+ * @returns
+ */
+function getDistance(point1, point2) {
+    const xDif = Math.pow(point2[0] - point1[0], 2);
+    const yDif = Math.pow(point2[1] - point1[1], 2);
+    const d = Math.pow(xDif + yDif, 0.5);
+    return d;
+}
+
+/**
+ *
+ * @param {canvas.context} ctx
+ * @param {string} hexColor
+ * @param {number} borderWidth
+ */
+const drawBorder = (ctx, hexColor, borderWidth) => {
+    const points = [];
+
+    const width = ctx.canvas.width + 150,
+        height = ctx.canvas.height + 150;
+
+    const imageData = ctx.getImageData(0, 0, width, height);
     const length = imageData.data.length;
 
-    const changeColor = (position) => {
-        if (imageData.data[position + 3] === 0) {
-            dataCopy.set([...hexToRgb(hexColor), 255], position);
+    const usePoint = (position, row, col) => {
+        if (imageData.data[position + 3] <= 1) {
+            points.push([col, row]);
         }
     };
 
+    let row = -1;
     for (let i = 0; i < length; i += 4) {
+        if (!(i % (width * 4))) {
+            row++;
+        }
+        const col = (i - row * width * 4) / 4;
+
         const top = i - width * 4;
         const bottom = i + width * 4;
         const left = i - 4;
@@ -43,22 +136,50 @@ const drawBorder = (ctx, hexColor) => {
             continue;
         }
 
-        // Change left, top, right and bottom neighbors colors if they are transparent
-        changeColor(left);
-        changeColor(top);
-        changeColor(right);
-        changeColor(bottom);
+        // Use left, top, right and bottom neighbors if they are transparent
+        usePoint(left, row, col);
+        usePoint(top, row, col);
+        usePoint(right, row, col);
+        usePoint(bottom, row, col);
 
-        // Changes corner neighbors colors if they are transparent
-        changeColor(topLeftCorner);
-        changeColor(topRightCorner);
-        changeColor(bottomLeftCorner);
-        changeColor(bottomRightCorner);
+        // Use corner neighbors if they are transparent
+        usePoint(topLeftCorner, row, col);
+        usePoint(topRightCorner, row, col);
+        usePoint(bottomLeftCorner, row, col);
+        usePoint(bottomRightCorner, row, col);
     }
 
-    imageData.data.set(dataCopy);
+    const shapes = constructShapes(points);
 
-    return imageData;
+    ctx.lineWidth = borderWidth;
+    ctx.strokeStyle = hexColor;
+    shapes.map((shape) => {
+        ctx.beginPath();
+        ctx.moveTo(...shape[0]);
+        shape.map((point, index) => {
+            if (index > 1) {
+                // Smooth lines
+                ctx.lineCap = "round";
+                ctx.lineJoin = "round";
+
+                // If it's further than 2 pixels then move to the next point
+                if (getDistance(shape[index - 1], point) > 2) {
+                    ctx.moveTo(...point);
+                } else {
+                    const prevPoint = shape[index - 1];
+                    const controlPointX = (prevPoint[0] + point[0]) / 2;
+                    const controlPointY = (prevPoint[1] + point[1]) / 2;
+
+                    ctx.quadraticCurveTo(
+                        ...shape[index - 1],
+                        controlPointX,
+                        controlPointY
+                    );
+                }
+            }
+        });
+        ctx.stroke();
+    });
 };
 
 export default drawBorder;

--- a/src/js/libs/image-border-effect.js
+++ b/src/js/libs/image-border-effect.js
@@ -1,0 +1,64 @@
+function hexToRgb(hex) {
+    var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+
+    return result
+        ? [
+              parseInt(result[1], 16),
+              parseInt(result[2], 16),
+              parseInt(result[3], 16),
+          ]
+        : [0, 0, 0];
+}
+
+const drawBorder = (ctx, hexColor) => {
+    const width = ctx.canvas.width,
+        height = ctx.canvas.height;
+    const imageData = ctx.getImageData(0, 0, width, height);
+
+    const dataCopy = new Uint8ClampedArray(imageData.data);
+    const length = imageData.data.length;
+
+    const changeColor = (position) => {
+        if (imageData.data[position + 3] === 0) {
+            dataCopy.set([...hexToRgb(hexColor), 255], position);
+        }
+    };
+
+    for (let i = 0; i < length; i += 4) {
+        const top = i - width * 4;
+        const bottom = i + width * 4;
+        const left = i - 4;
+        const right = i + 4;
+        const topLeftCorner = i - width * 4 - 4;
+        const topRightCorner = i - width * 4 + 4;
+        const bottomLeftCorner = i + width * 4 - 4;
+        const bottomRightCorner = i + width * 4 + 4;
+
+        let isNoneTransparent = imageData.data[i + 3] > 0;
+        if (
+            !isNoneTransparent ||
+            i % (width * 4) === 0 ||
+            i + width * 4 >= length
+        ) {
+            continue;
+        }
+
+        // Change left, top, right and bottom neighbors colors if they are transparent
+        changeColor(left);
+        changeColor(top);
+        changeColor(right);
+        changeColor(bottom);
+
+        // Changes corner neighbors colors if they are transparent
+        changeColor(topLeftCorner);
+        changeColor(topRightCorner);
+        changeColor(bottomLeftCorner);
+        changeColor(bottomRightCorner);
+    }
+
+    imageData.data.set(dataCopy);
+
+    return imageData;
+};
+
+export default drawBorder;

--- a/src/js/modules/effects/borders.js
+++ b/src/js/modules/effects/borders.js
@@ -71,10 +71,10 @@ class Effects_borders_class {
     render_post(ctx, data, layer) {
         const size = Math.max(0, data.params.size);
 
-        let x = layer.x;
-        let y = layer.y;
-        let width = parseInt(layer.width);
-        let height = parseInt(layer.height);
+        const x = layer.x;
+        const y = layer.y;
+        const width = parseInt(layer.width);
+        const height = parseInt(layer.height);
 
         //legacy check
         if (x == null) x = 0;
@@ -84,43 +84,24 @@ class Effects_borders_class {
 
         ctx.save();
 
-        const offsets = [-1, -1, 0, -1, 1, -1, -1, 0, 1, 0, -1, 1, 0, 1, 1, 1]; // offset array
+        //set styles
+        ctx.strokeStyle = data.params.color;
+        ctx.lineWidth = size;
 
-        // Create an isolated canvas to draw our bordered image
-        const newCanvas = document.createElement("canvas");
-        newCanvas.height = 2 * Math.max(ctx.canvas.height, layer.height);
-        newCanvas.width = 2 * Math.max(ctx.canvas.width, layer.width);
+        //draw with rotation support
+        ctx.translate(layer.x + width / 2, layer.y + height / 2);
+        ctx.rotate((layer.rotate * Math.PI) / 180);
+        const x_new = -width / 2;
+        const y_new = -height / 2;
 
-        let newCtx = newCanvas.getContext("2d");
-        // Draw the same image, but scaled by the border size
-        for (let i = 0; i < offsets.length; i += 2) {
-            newCtx.drawImage(
-                layer.link,
-                x + offsets[i] * size,
-                y + offsets[i + 1] * size,
-                width,
-                height
-            );
-        }
-
-        // Set the color
-        newCtx.fillStyle = data.params.color;
-        // Now we will intersect the above drawn image with the rectangle below
-        // As a result we will have an object having the same shape of the original image, but scaled by the border size
-        newCtx.globalCompositeOperation = "source-in";
-        newCtx.fillRect(
-            x - size,
-            y - size,
-            width + 2 * size,
-            height + 2 * size
+        ctx.beginPath();
+        ctx.rect(
+            x_new - size * 0.5,
+            y_new - size * 0.5,
+            width + size,
+            height + size
         );
-
-        // Now draw our image from isolated canvas to the main one
-        ctx.drawImage(newCanvas, 0, 0);
-
-        // Draw the original image in normal size on top of the newly created object
-        ctx.globalCompositeOperation = "source-over";
-        ctx.drawImage(layer.link, x, y, width, height);
+        ctx.stroke();
 
         ctx.restore();
     }

--- a/src/js/modules/effects/borders.js
+++ b/src/js/modules/effects/borders.js
@@ -1,107 +1,122 @@
-import app from './../../app.js';
-import config from './../../config.js';
-import Base_layers_class from './../../core/base-layers.js';
-import Dialog_class from './../../libs/popup.js';
-import alertify from './../../../../node_modules/alertifyjs/build/alertify.min.js';
+import app from "./../../app.js";
+import config from "./../../config.js";
+import Base_layers_class from "./../../core/base-layers.js";
+import Dialog_class from "./../../libs/popup.js";
+import alertify from "./../../../../node_modules/alertifyjs/build/alertify.min.js";
 import Effects_browser_class from "./browser";
 
 class Effects_borders_class {
+    constructor() {
+        this.POP = new Dialog_class();
+        this.Base_layers = new Base_layers_class();
+        this.Effects_browser = new Effects_browser_class();
+    }
 
-	constructor() {
-		this.POP = new Dialog_class();
-		this.Base_layers = new Base_layers_class();
-		this.Effects_browser = new Effects_browser_class();
-	}
+    borders(filter_id) {
+        if (config.layer.type == null) {
+            alertify.error("Layer is empty.");
+            return;
+        }
 
-	borders(filter_id) {
-		if (config.layer.type == null) {
-			alertify.error('Layer is empty.');
-			return;
-		}
+        var _this = this;
+        var filter = this.Base_layers.find_filter_by_id(filter_id, "borders");
 
-		var _this = this;
-		var filter = this.Base_layers.find_filter_by_id(filter_id, 'borders');
+        var settings = {
+            title: "Borders",
+            params: [
+                {
+                    name: "color",
+                    title: "Color:",
+                    value: (filter.color ??= config.COLOR),
+                    type: "color",
+                },
+                { name: "size", title: "Size:", value: (filter.size ??= 10) },
+            ],
+            on_finish: function (params) {
+                var target = Math.min(config.WIDTH, config.HEIGHT);
+                _this.add_borders(params, filter_id);
+            },
+        };
+        var rotate = config.layer.rotate;
+        config.layer.rotate = 0;
+        this.Base_layers.disable_filter(filter_id);
+        this.POP.show(settings);
+        config.layer.rotate = rotate;
+        this.Base_layers.disable_filter(null);
+    }
 
-		var settings = {
-			title: 'Borders',
-			params: [
-				{name: "color", title: "Color:", value: filter.color ??= config.COLOR, type: 'color'},
-				{name: "size", title: "Size:", value: filter.size ??= 10},
-			],
-			on_finish: function (params) {
-				var target = Math.min(config.WIDTH, config.HEIGHT);
-				_this.add_borders(params, filter_id);
-			},
-		};
-		var rotate = config.layer.rotate;
-		config.layer.rotate = 0;
-		this.Base_layers.disable_filter(filter_id);
-		this.POP.show(settings);
-		config.layer.rotate = rotate;
-		this.Base_layers.disable_filter(null);
-	}
+    demo(canvas_id, canvas_thumb) {
+        var canvas = document.getElementById(canvas_id);
+        var ctx = canvas.getContext("2d");
 
-	demo(canvas_id, canvas_thumb){
-		var canvas = document.getElementById(canvas_id);
-		var ctx = canvas.getContext("2d");
+        //draw
+        ctx.drawImage(
+            canvas_thumb,
+            5,
+            5,
+            this.Effects_browser.preview_width - 10,
+            this.Effects_browser.preview_height - 10
+        );
 
-		//draw
-		ctx.drawImage(canvas_thumb,
-			5, 5,
-			this.Effects_browser.preview_width - 10, this.Effects_browser.preview_height - 10);
+        //add borders
+        ctx.strokeStyle = "#000000";
+        ctx.lineWidth = 10;
+        ctx.beginPath();
+        ctx.rect(0, 0, canvas.width, canvas.height);
+        ctx.stroke();
+    }
 
-		//add borders
-		ctx.strokeStyle = '#000000';
-		ctx.lineWidth = 10;
-		ctx.beginPath();
-		ctx.rect(0, 0, canvas.width, canvas.height);
-		ctx.stroke();
-	}
+    render_pre(ctx, data) {}
 
-	render_pre(ctx, data) {
+    render_post(ctx, data, layer) {
+        var size = Math.max(0, data.params.size);
 
-	}
+        var x = layer.x;
+        var y = layer.y;
+        var width = parseInt(layer.width);
+        var height = parseInt(layer.height);
 
-	render_post(ctx, data, layer){
-		var size = Math.max(0, data.params.size);
+        //legacy check
+        if (x == null) x = 0;
+        if (y == null) y = 0;
+        if (!width) width = config.WIDTH;
+        if (!height) height = config.HEIGHT;
 
-		var x = layer.x;
-		var y = layer.y;
-		var width = parseInt(layer.width);
-		var height = parseInt(layer.height);
+        ctx.save();
 
-		//legacy check
-		if(x == null) x = 0;
-		if(y == null) y = 0;
-		if(!width) width = config.WIDTH;
-		if(!height) height = config.HEIGHT;
+        //set styles
+        ctx.strokeStyle = data.params.color;
+        ctx.lineWidth = size;
 
-		ctx.save();
+        //draw with rotation support
+        ctx.translate(layer.x + width / 2, layer.y + height / 2);
+        ctx.rotate((layer.rotate * Math.PI) / 180);
+        var x_new = -width / 2;
+        var y_new = -height / 2;
 
-		//set styles
-		ctx.strokeStyle = data.params.color;
-		ctx.lineWidth = size;
+        ctx.beginPath();
+        ctx.rect(
+            x_new - size * 0.5,
+            y_new - size * 0.5,
+            width + size,
+            height + size
+        );
+        ctx.stroke();
 
-		//draw with rotation support
-		ctx.translate(layer.x + width / 2, layer.y + height / 2);
-		ctx.rotate(layer.rotate * Math.PI / 180);
-		var x_new = -width / 2;
-		var y_new = -height / 2;
+        ctx.restore();
+    }
 
-		ctx.beginPath();
-		ctx.rect(x_new - size * 0.5, y_new - size * 0.5, width + size, height + size);
-		ctx.stroke();
-
-		ctx.restore();
-	}
-
-	add_borders(params, filter_id) {
-		//apply effect
-		return app.State.do_action(
-			new app.Actions.Add_layer_filter_action(config.layer.id, 'borders', params, filter_id)
-		);
-	}
-
+    add_borders(params, filter_id) {
+        //apply effect
+        return app.State.do_action(
+            new app.Actions.Add_layer_filter_action(
+                config.layer.id,
+                "borders",
+                params,
+                filter_id
+            )
+        );
+    }
 }
 
 export default Effects_borders_class;

--- a/src/js/modules/effects/borders.js
+++ b/src/js/modules/effects/borders.js
@@ -4,6 +4,7 @@ import Base_layers_class from "./../../core/base-layers.js";
 import Dialog_class from "./../../libs/popup.js";
 import alertify from "./../../../../node_modules/alertifyjs/build/alertify.min.js";
 import Effects_browser_class from "./browser";
+import drawBorder from "../../libs/image-border-effect.js";
 
 class Effects_borders_class {
     constructor() {
@@ -48,7 +49,6 @@ class Effects_borders_class {
     demo(canvas_id, canvas_thumb) {
         var canvas = document.getElementById(canvas_id);
         var ctx = canvas.getContext("2d");
-
         //draw
         ctx.drawImage(
             canvas_thumb,
@@ -70,7 +70,6 @@ class Effects_borders_class {
 
     render_post(ctx, data, layer) {
         const size = Math.max(0, data.params.size);
-
         const x = layer.x;
         const y = layer.y;
         const width = parseInt(layer.width);
@@ -84,24 +83,18 @@ class Effects_borders_class {
 
         ctx.save();
 
-        //set styles
-        ctx.strokeStyle = data.params.color;
-        ctx.lineWidth = size;
+        // We need to get aspect ratio for preview canvas and for the main canvas when it gets zoom < 1
+        const aspectRatio = ctx.canvas.height / config.HEIGHT;
 
-        //draw with rotation support
-        ctx.translate(layer.x + width / 2, layer.y + height / 2);
-        ctx.rotate((layer.rotate * Math.PI) / 180);
-        const x_new = -width / 2;
-        const y_new = -height / 2;
-
-        ctx.beginPath();
-        ctx.rect(
-            x_new - size * 0.5,
-            y_new - size * 0.5,
-            width + size,
-            height + size
-        );
-        ctx.stroke();
+        let borderWidth = size * aspectRatio;
+        // This is the case when it's zoomed more than the canvas size
+        if (aspectRatio >= 1 && aspectRatio <= config.ZOOM) {
+            borderWidth = size * config.ZOOM;
+        }
+        // Draw border multiple times to get the necessary with in pixels
+        for (let i = 0; i < borderWidth; i++) {
+            ctx.putImageData(drawBorder(ctx, data.params.color), 0, 0);
+        }
 
         ctx.restore();
     }

--- a/src/js/modules/effects/borders.js
+++ b/src/js/modules/effects/borders.js
@@ -69,12 +69,12 @@ class Effects_borders_class {
     render_pre(ctx, data) {}
 
     render_post(ctx, data, layer) {
-        var size = Math.max(0, data.params.size);
+        const size = Math.max(0, data.params.size);
 
-        var x = layer.x;
-        var y = layer.y;
-        var width = parseInt(layer.width);
-        var height = parseInt(layer.height);
+        let x = layer.x;
+        let y = layer.y;
+        let width = parseInt(layer.width);
+        let height = parseInt(layer.height);
 
         //legacy check
         if (x == null) x = 0;
@@ -84,24 +84,26 @@ class Effects_borders_class {
 
         ctx.save();
 
-        //set styles
-        ctx.strokeStyle = data.params.color;
-        ctx.lineWidth = size;
+        var dArr = [-1, -1, 0, -1, 1, -1, -1, 0, 1, 0, -1, 1, 0, 1, 1, 1]; // offset array
 
-        //draw with rotation support
-        ctx.translate(layer.x + width / 2, layer.y + height / 2);
-        ctx.rotate((layer.rotate * Math.PI) / 180);
-        var x_new = -width / 2;
-        var y_new = -height / 2;
+        // Draw the same image, but scaled by the border size
+        for (let i = 0; i < dArr.length; i += 2)
+            ctx.drawImage(
+                layer.link,
+                x + dArr[i] * size,
+                y + dArr[i + 1] * size
+            );
 
-        ctx.beginPath();
-        ctx.rect(
-            x_new - size * 0.5,
-            y_new - size * 0.5,
-            width + size,
-            height + size
-        );
-        ctx.stroke();
+        // Set the color
+        ctx.fillStyle = data.params.color;
+        // Now we will intersect the above drawn image with the rectangle below
+        // As a result we will have an object having the same shape of the original image, but scaled by the border size
+        ctx.globalCompositeOperation = "source-in";
+        ctx.fillRect(0, 0, width + size, height + size);
+
+        // Draw the original image in normal size on top of the newly created object
+        ctx.globalCompositeOperation = "source-over";
+        ctx.drawImage(layer.link, x, y);
 
         ctx.restore();
     }

--- a/src/js/modules/effects/borders.js
+++ b/src/js/modules/effects/borders.js
@@ -84,26 +84,29 @@ class Effects_borders_class {
 
         ctx.save();
 
-        var dArr = [-1, -1, 0, -1, 1, -1, -1, 0, 1, 0, -1, 1, 0, 1, 1, 1]; // offset array
+        const offsets = [-1, -1, 0, -1, 1, -1, -1, 0, 1, 0, -1, 1, 0, 1, 1, 1]; // offset array
 
         // Draw the same image, but scaled by the border size
-        for (let i = 0; i < dArr.length; i += 2)
+        for (let i = 0; i < offsets.length; i += 2) {
             ctx.drawImage(
                 layer.link,
-                x + dArr[i] * size,
-                y + dArr[i + 1] * size
+                x + offsets[i] * size,
+                y + offsets[i + 1] * size,
+                width,
+                height
             );
+        }
 
         // Set the color
         ctx.fillStyle = data.params.color;
         // Now we will intersect the above drawn image with the rectangle below
         // As a result we will have an object having the same shape of the original image, but scaled by the border size
         ctx.globalCompositeOperation = "source-in";
-        ctx.fillRect(0, 0, width + size, height + size);
+        ctx.fillRect(x - size, y - size, width + 2 * size, height + 2 * size);
 
         // Draw the original image in normal size on top of the newly created object
         ctx.globalCompositeOperation = "source-over";
-        ctx.drawImage(layer.link, x, y);
+        ctx.drawImage(layer.link, x, y, width, height);
 
         ctx.restore();
     }

--- a/src/js/modules/effects/borders.js
+++ b/src/js/modules/effects/borders.js
@@ -86,9 +86,15 @@ class Effects_borders_class {
 
         const offsets = [-1, -1, 0, -1, 1, -1, -1, 0, 1, 0, -1, 1, 0, 1, 1, 1]; // offset array
 
+        // Create an isolated canvas to draw our bordered image
+        const newCanvas = document.createElement("canvas");
+        newCanvas.height = 2 * Math.max(ctx.canvas.height, layer.height);
+        newCanvas.width = 2 * Math.max(ctx.canvas.width, layer.width);
+
+        let newCtx = newCanvas.getContext("2d");
         // Draw the same image, but scaled by the border size
         for (let i = 0; i < offsets.length; i += 2) {
-            ctx.drawImage(
+            newCtx.drawImage(
                 layer.link,
                 x + offsets[i] * size,
                 y + offsets[i + 1] * size,
@@ -98,11 +104,19 @@ class Effects_borders_class {
         }
 
         // Set the color
-        ctx.fillStyle = data.params.color;
+        newCtx.fillStyle = data.params.color;
         // Now we will intersect the above drawn image with the rectangle below
         // As a result we will have an object having the same shape of the original image, but scaled by the border size
-        ctx.globalCompositeOperation = "source-in";
-        ctx.fillRect(x - size, y - size, width + 2 * size, height + 2 * size);
+        newCtx.globalCompositeOperation = "source-in";
+        newCtx.fillRect(
+            x - size,
+            y - size,
+            width + 2 * size,
+            height + 2 * size
+        );
+
+        // Now draw our image from isolated canvas to the main one
+        ctx.drawImage(newCanvas, 0, 0);
 
         // Draw the original image in normal size on top of the newly created object
         ctx.globalCompositeOperation = "source-over";


### PR DESCRIPTION
### Related issue:
https://github.com/viliusle/miniPaint/issues/266

### Result

Previous implementation
<img width="381" alt="Screen Shot 2021-09-25 at 14 02 16" src="https://user-images.githubusercontent.com/3371013/134767498-11a93abc-f768-4903-8e3c-6d73bcd091e3.png">

Current implementation
<img width="363" alt="Screen Shot 2021-09-25 at 14 01 22" src="https://user-images.githubusercontent.com/3371013/134767502-a419f652-716c-4570-8980-df68b3e4d1b7.png">

